### PR TITLE
Allow set_temperature when only hvac_modes only contains heat_cool

### DIFF
--- a/custom_components/climate_template/climate.py
+++ b/custom_components/climate_template/climate.py
@@ -595,9 +595,12 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
                     CONF_TARGET_TEMPERATURE_TEMPLATE,
                 )
         else:
-            if self._action_temperature:
+            if (
+                self._action_temperature
+                and HVACMode.HEAT_COOL not in self._attr_hvac_modes
+            ):
                 _LOGGER.warning(
-                    "Entity '%s' has no hvac mode auto, heat or cool configured, but there is action '%s' configured.",
+                    "Entity '%s' has no hvac mode auto, heat, cool, or heat_cool configured, but there is action '%s' configured.",
                     self._attr_name,
                     CONF_SET_TEMPERATURE_ACTION,
                 )


### PR DESCRIPTION
Currently, if a template sets hvac_modes to ["off", "heat_cool"], and set_temperature to some action, the verification logic incorrectly assumes that set_temperature is misplaced, and clears it.

This patch adds a quick check to ensure set_temperature isn't incorrectly cleared when heat_cool is present in hvac_modes.