### PR TITLE
Fix template attributes never updating after a live reload

### DIFF
--- a/custom_components/climate_template/climate.py
+++ b/custom_components/climate_template/climate.py
@@ -889,10 +889,31 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
                     self._presets = self._validate_presets(self._presets)
 
         _LOGGER.debug(
-            "Entity '%s' registering templates callbacks.",
+            "Entity '%s' successfully registered to homeassistant.",
             self._attr_name,
         )
 
+    @callback
+    def _async_setup_templates(self) -> None:
+        """Register this entity's own templates, then the base class's.
+
+        Must run BEFORE TemplateEntity.async_added_to_hass() reaches
+        async_at_start(self.hass, self._async_template_startup): that call runs
+        _async_template_startup() SYNCHRONOUSLY when hass.is_running is already
+        True (i.e. on every live reload after boot, not just cold start), and
+        _async_template_startup() only wires up async_track_template_result()
+        for whatever is in self._template_attrs AT THAT MOMENT. Registering
+        these template attributes later (e.g. inline in an overridden
+        async_added_to_hass(), after the super() call) misses that window: the
+        attribute is added to self._template_attrs but never included in the
+        tracked set, so it renders once (or falls back to the restored
+        previous_state) and then never updates again until a full HA restart
+        (only then does hass.is_running start False, deferring
+        _async_template_startup to EVENT_HOMEASSISTANT_START, by which point
+        registration has long since finished). This mirrors the pattern core
+        template entities use, e.g. StateSensorEntity in
+        homeassistant/components/template/sensor.py.
+        """
         # Register templates callback.
         if self._template_hvac_mode:
             self.add_template_attribute(
@@ -1002,18 +1023,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
                 none_on_template_error=True,
             )
 
-        # Template attributes are registered dynamically here, after the
-        # parent async_added_to_hass has already run.
-        # Explicitly start template tracking so callbacks are evaluated and
-        # entity state/attributes stay updated.
-        async_setup_templates = getattr(self, "_async_setup_templates", None)
-        if callable(async_setup_templates):
-            async_setup_templates()
-
-        _LOGGER.debug(
-            "Entity '%s' successfully registered to homeassistant.",
-            self._attr_name,
-        )
+        super()._async_setup_templates()
 
     def _validate_value(self, attr, value, format):
         if value is None:


### PR DESCRIPTION
## Disclaimer:

The analisys, fix and description below is **fully created by Claude Code**. I did not do my own review/analisys and I can only confirm that it fixes described problem. **Please validate**.

## Summary

`TemplateClimate` registers its own templated attributes (`hvac_mode`, `current_temperature`,
`target_temperature`, `fan_mode`, `swing_mode`, `current_humidity`, `hvac_action`, `presets`,
`target_humidity`, `target_temperature_high`/`_low`) too late in the entity lifecycle. They render
once — either from the initial template evaluation or from the `RestoreEntity` `previous_state`
fallback — and then **freeze permanently**, never updating again, until the entire Home Assistant
process is restarted. A live reload of the `climate` platform (`climate.reload`,
`homeassistant.reload_all`, or anything else that recreates the entity while HA is already running)
reproduces it every time.

This is easy to miss in testing because the frozen value often stays *plausible* for a while (e.g.
an average across several rooms that doesn't move much), so it can go unnoticed for a long time
before someone compares it against ground truth.

## Root cause

`TemplateClimate.async_added_to_hass()` does:

```python
async def async_added_to_hass(self):
    await super().async_added_to_hass()   # <- see below
    ...
    if self._template_hvac_mode:
        self.add_template_attribute("_hvac_mode", self._template_hvac_mode, ...)
    ... # current_temperature, target_temperature, fan_mode, swing_mode, etc — all registered here
```

Core `TemplateEntity.async_added_to_hass()` (`homeassistant/components/template/template_entity.py`)
does:

```python
async def async_added_to_hass(self) -> None:
    self._async_setup_templates()                             # virtual call
    async_at_start(self.hass, self._async_template_startup)   # captures self._template_attrs NOW
```

`_async_template_startup()` is the *only* place that builds `TrackTemplate` objects from
`self._template_attrs` and calls `async_track_template_result(...)` — i.e. the only place live
tracking actually gets wired up. It only picks up whatever is in `self._template_attrs` **at the
moment it runs**.

`async_at_start()` (`homeassistant/helpers/start.py`): if `hass.is_running` is already `True` —
true for every reload after boot, not just a cold start — it invokes the (`@callback`-decorated)
target **synchronously and immediately**, not scheduled. So `_async_template_startup()` fires the
instant `super().async_added_to_hass()` executes it, **before** `TemplateClimate`'s own code
(further down the same method) has had a chance to call `add_template_attribute()` for
`_hvac_mode` / `_current_temperature` / `_target_temperature` / etc. Those get added to
`self._template_attrs` too late to ever be included in the tracked set — they're registered, but
never subscribed to further template re-evaluation.

Only a genuine cold boot works around this by coincidence: at startup `hass.is_running` is `False`
while platforms are being set up, so `async_at_start()` *defers* `_async_template_startup()` until
`EVENT_HOMEASSISTANT_START` fires — by which point the whole `async_added_to_hass()` coroutine
(including the late registrations) has already finished, so `self._template_attrs` happens to be
complete when the deferred callback runs.

I confirmed this empirically: after a live `homeassistant.reload_all`, a `climate_template` entity's
`current_temperature` attribute stayed frozen at the exact value it computed at reload time,
independently verified by injecting a synthetic MQTT state change on an upstream sensor and watching
the entity fail to react — then confirmed it *did* react correctly immediately after a full HA
restart.

### The previous fix attempt (`6c6395a`, "fix template not updating") is a no-op for this bug

That commit added, at the end of the same registration block:

```python
async_setup_templates = getattr(self, "_async_setup_templates", None)
if callable(async_setup_templates):
    async_setup_templates()
```

`_async_setup_templates()` is a different method from `_async_template_startup()` — it only
(re-)registers the *base* `TemplateEntity`'s own template fields (`icon_template`,
`availability_template`, etc.), redundantly, since they were already registered on the first pass.
It does **not** call `async_track_template_result()` again, so the newly-added `hvac_mode` /
`current_temperature` / `target_temperature` / etc. templates registered earlier in the same method
are still never included in the tracked set. I confirmed the values stay frozen even with this fix
applied — the "fix" only masked a slightly different, narrower symptom (or none at all, depending on
which base fields are configured).

## Fix

Move all of `TemplateClimate`'s `add_template_attribute()` calls out of `async_added_to_hass()` and
into an **overridden `_async_setup_templates()`** method, calling `super()._async_setup_templates()`
at the end — this is exactly the pattern core's own `StateSensorEntity` uses
(`homeassistant/components/template/sensor.py`), which is the class backing every plain
`template: sensor:` in Home Assistant and has none of this staleness problem:

```python
class StateSensorEntity(TemplateEntity, SensorEntity):
    @callback
    def _async_setup_templates(self) -> None:
        self.add_template_attribute("_attr_native_value", self._template, None, self._update_state)
        ...
        super()._async_setup_templates()
```

Since `_async_setup_templates()` is called as the very first line of the base class's
`async_added_to_hass()` — *before* `async_at_start(...)` — overriding it guarantees every
template attribute is registered before live tracking is wired up, on both cold boot and every
subsequent live reload. No manual re-triggering needed, and the `getattr(...)` workaround from
`6c6395a` can be removed entirely.

The `RestoreEntity` `previous_state` restoration logic in `async_added_to_hass()` is left exactly
where it is — it's unrelated and correct as a pre-render default.

## Testing

- Verified locally: after this fix, `current_temperature` (and the other templated attributes)
  update live and immediately, both on cold boot and after a live `homeassistant.reload_all` that
  recreates the entity.
- Verified the *old* behavior reproduces the reported symptom exactly: frozen value surviving
  multiple live reloads, self-correcting only on a full process restart.
- No changes to `RestoreEntity` behavior, template syntax, or any public config schema — this is a
  pure lifecycle-ordering fix.

## Diff

Only `custom_components/climate_template/climate.py` is touched — the entire diff is moving an
existing block of code into a new method plus a two-line change at each end (adding the method
signature/docstring, replacing the dead `getattr(...)` block with `super()._async_setup_templates()`).
